### PR TITLE
Make it possible to build in parallel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 import os
 
 
-version = "0.1.4"
+version = "0.1.5"
 long_description = "\n".join([
     open(os.path.join("README.rst")).read(),
     open(os.path.join("AUTHORS.rst")).read(),

--- a/src/sphinxcontrib/nvd3/__init__.py
+++ b/src/sphinxcontrib/nvd3/__init__.py
@@ -5,3 +5,7 @@ from sphinxcontrib.nvd3 import directives
 
 def setup(app):
     directives.setup(app)
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }


### PR DESCRIPTION
Hi @shkumagai,

This PR makes it possible to use the extension and build the doc with the parallelized option (it's much faster!). Check out the `-j` option in [sphinx-build man page](http://www.sphinx-doc.org/en/1.5.1/man/sphinx-build.html).

This PR also includes a version bump :)